### PR TITLE
Support arrays as additionalProperties

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -485,7 +485,7 @@ func (c *compileCtx) compileMap(name string, s *openapi.Schema) (protobuf.Type, 
 		var err error
 		typ, err = c.compileSchema(name, s)
 		if err != nil {
-			return nil, errors.Wrap(err, `failed to compile blah type`)
+			return nil, errors.Wrap(err, `failed to compile array type`)
 		}
 	case s.Ref != "":
 		var err error

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -481,6 +481,12 @@ func (c *compileCtx) compileMap(name string, s *openapi.Schema) (protobuf.Type, 
 	var typ protobuf.Type
 
 	switch {
+	case s.Type.Contains("array"):
+		var err error
+		typ, err = c.compileSchema(name, s)
+		if err != nil {
+			return nil, errors.Wrap(err, `failed to compile blah type`)
+		}
 	case s.Ref != "":
 		var err error
 		typ, err = c.compileReferenceSchema(name, s)


### PR DESCRIPTION
This allows openapi additionalProperties to be arrays. Currently if additionalProperties is an array it fails .